### PR TITLE
fix missing of <vector>

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ add_library(dso ${dso_SOURCE_FILES} ${dso_opencv_SOURCE_FILES} ${dso_pangolin_SO
 if (OpenCV_FOUND AND Pangolin_FOUND)
 	message("--- compiling dso_dataset.")
 	add_executable(dso_dataset ${PROJECT_SOURCE_DIR}/src/main_dso_pangolin.cpp )
-	target_link_libraries(dso_dataset dso boost_system boost_thread csparse cxsparse ${LIBZIP_LIBRARY} ${Pangolin_LIBRARIES} ${OpenCV_LIBS})
+    target_link_libraries(dso_dataset dso boost_system boost_thread cxsparse ${LIBZIP_LIBRARY} ${Pangolin_LIBRARIES} ${OpenCV_LIBS})
 else()
 	message("--- not building dso_dataset, since either don't have openCV or Pangolin.")
 endif()

--- a/src/IOWrapper/ImageDisplay.h
+++ b/src/IOWrapper/ImageDisplay.h
@@ -24,6 +24,7 @@
 
 
 #pragma once
+#include <vector>
 #include "util/NumType.h"
 #include "util/MinimalImage.h"
 

--- a/src/IOWrapper/Output3DWrapper.h
+++ b/src/IOWrapper/Output3DWrapper.h
@@ -24,6 +24,7 @@
 
 
 #pragma once
+#include <vector>
 #include <string>
 
 #include "util/NumType.h"


### PR DESCRIPTION
- need to add the <vector> header file to be built on mac
- remove csparse link. It seems that csparse does not belong to
suitesparse anymore and won't be installed.