### PR TITLE
Cmake - pkgconfig and installation files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ set(CMAKE_CXX_FLAGS
    "${SSE_FLAGS} -O3 -g -std=c++0x -march=native"
 #   "${SSE_FLAGS} -O3 -g -std=c++0x -fno-omit-frame-pointer"
 )
+option(DSO_BUILD_STATIC_LIBRARY        "Build a static dso library, instead of shared" ON)
 
 # Sources files
 set(dso_SOURCE_FILES
@@ -106,9 +107,27 @@ endif()
 
 
 # compile main library.
-include_directories( ${CSPARSE_INCLUDE_DIR} ${CHOLMOD_INCLUDE_DIR}) 
-add_library(dso ${dso_SOURCE_FILES} ${dso_opencv_SOURCE_FILES} ${dso_pangolin_SOURCE_FILES})
+include_directories( ${CSPARSE_INCLUDE_DIR} ${CHOLMOD_INCLUDE_DIR})
 
+if (DSO_BUILD_STATIC_LIBRARY)
+    message("--- dso static library selected.")
+    add_library(dso ${dso_SOURCE_FILES} ${dso_opencv_SOURCE_FILES} ${dso_pangolin_SOURCE_FILES})
+    install (TARGETS dso ARCHIVE DESTINATION lib COMPONENT libraries)
+else()
+    message("--- dso dynamic library selected.")
+    add_library(dso SHARED ${dso_SOURCE_FILES} ${dso_opencv_SOURCE_FILES} ${dso_pangolin_SOURCE_FILES})
+    target_link_libraries(dso boost_system boost_thread cxsparse)
+    if (HAS_ZIPLIB)
+        target_link_libraries(dso ${LIBZIP_LIBRARY})
+    endif()
+    if (HAS_PANGOLIN)
+        target_link_libraries(dso ${Pangolin_LIBRARIES})
+    endif()
+    if (HAS_OPENCV)
+        target_link_libraries(dso ${OpenCV_LIBS})
+    endif()
+    install (TARGETS dso LIBRARY DESTINATION lib COMPONENT libraries)
+endif()
 #set_property( TARGET dso APPEND_STRING PROPERTY COMPILE_FLAGS -Wall )
 
 
@@ -120,4 +139,16 @@ if (OpenCV_FOUND AND Pangolin_FOUND)
 else()
 	message("--- not building dso_dataset, since either don't have openCV or Pangolin.")
 endif()
+
+file(GLOB dso_HEADER_FILES "${PROJECT_SOURCE_DIR}/src/FullSystem/*.h")
+
+install (FILES ${dso_HEADER_FILES} DESTINATION include/dso/FullSystem)
+
+file(GLOB dso_HEADER_FILES "${PROJECT_SOURCE_DIR}/src/OptimizationBackend/*.h")
+
+install (FILES ${dso_HEADER_FILES} DESTINATION include/dso/OptimizationBackend)
+
+file(GLOB dso_HEADER_FILES "${PROJECT_SOURCE_DIR}/src/util/*.h")
+
+install (FILES ${dso_HEADER_FILES} DESTINATION include/dso/util)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ set(BUILD_TYPE Release)
 
 set(EXECUTABLE_OUTPUT_PATH bin)
 set(LIBRARY_OUTPUT_PATH lib)
+set(INCLUDE_OUTPUT_PATH include/dso)
+set(CMAKE_OUTPUT_PATH ${LIBRARY_OUTPUT_PATH}/cmake/dso)
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 # required libraries
@@ -112,7 +114,7 @@ include_directories( ${CSPARSE_INCLUDE_DIR} ${CHOLMOD_INCLUDE_DIR})
 if (DSO_BUILD_STATIC_LIBRARY)
     message("--- dso static library selected.")
     add_library(dso ${dso_SOURCE_FILES} ${dso_opencv_SOURCE_FILES} ${dso_pangolin_SOURCE_FILES})
-    install (TARGETS dso ARCHIVE DESTINATION lib COMPONENT libraries)
+    install (TARGETS dso ARCHIVE DESTINATION ${LIBRARY_OUTPUT_PATH} COMPONENT libraries)
 else()
     message("--- dso dynamic library selected.")
     add_library(dso SHARED ${dso_SOURCE_FILES} ${dso_opencv_SOURCE_FILES} ${dso_pangolin_SOURCE_FILES})
@@ -126,7 +128,7 @@ else()
     if (HAS_OPENCV)
         target_link_libraries(dso ${OpenCV_LIBS})
     endif()
-    install (TARGETS dso LIBRARY DESTINATION lib COMPONENT libraries)
+    install (TARGETS dso LIBRARY DESTINATION ${LIBRARY_OUTPUT_PATH} COMPONENT libraries)
 endif()
 #set_property( TARGET dso APPEND_STRING PROPERTY COMPILE_FLAGS -Wall )
 
@@ -142,13 +144,13 @@ endif()
 
 file(GLOB dso_HEADER_FILES "${PROJECT_SOURCE_DIR}/src/FullSystem/*.h")
 
-install (FILES ${dso_HEADER_FILES} DESTINATION include/dso/FullSystem)
+install (FILES ${dso_HEADER_FILES} DESTINATION ${INCLUDE_OUTPUT_PATH}/FullSystem)
 
 file(GLOB dso_HEADER_FILES "${PROJECT_SOURCE_DIR}/src/OptimizationBackend/*.h")
 
-install (FILES ${dso_HEADER_FILES} DESTINATION include/dso/OptimizationBackend)
+install (FILES ${dso_HEADER_FILES} DESTINATION ${INCLUDE_OUTPUT_PATH}/OptimizationBackend)
 
 file(GLOB dso_HEADER_FILES "${PROJECT_SOURCE_DIR}/src/util/*.h")
 
-install (FILES ${dso_HEADER_FILES} DESTINATION include/dso/util)
+install (FILES ${dso_HEADER_FILES} DESTINATION ${INCLUDE_OUTPUT_PATH}/util)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,10 @@ file(GLOB dso_HEADER_FILES "${PROJECT_SOURCE_DIR}/src/OptimizationBackend/*.h")
 
 install (FILES ${dso_HEADER_FILES} DESTINATION ${INCLUDE_OUTPUT_PATH}/OptimizationBackend)
 
+file(GLOB dso_HEADER_FILES "${PROJECT_SOURCE_DIR}/src/IOWrapper/*.h")
+
+install (FILES ${dso_HEADER_FILES} DESTINATION ${INCLUDE_OUTPUT_PATH}/IOWrapper)
+
 file(GLOB dso_HEADER_FILES "${PROJECT_SOURCE_DIR}/src/util/*.h")
 
 install (FILES ${dso_HEADER_FILES} DESTINATION ${INCLUDE_OUTPUT_PATH}/util)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,10 @@ file(GLOB dso_HEADER_FILES "${PROJECT_SOURCE_DIR}/src/util/*.h")
 
 install (FILES ${dso_HEADER_FILES} DESTINATION ${INCLUDE_OUTPUT_PATH}/util)
 
+#DSO comes with its own version of Sophus (TODO try to get the library from https://github.com/strasdat/Sophus)
+file(GLOB SOPHUS_HEADER_FILES "${PROJECT_SOURCE_DIR}/thirdparty/Sophus/sophus/*.hpp")
+install (FILES ${SOPHUS_HEADER_FILES} DESTINATION ${INCLUDE_OUTPUT_PATH}/sophus)
+
 macro(libraries_for_pkgconfig VARNAME)
     foreach(__lib ${ARGN})
         string(STRIP __lib ${__lib})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ set(EXECUTABLE_OUTPUT_PATH bin)
 set(LIBRARY_OUTPUT_PATH lib)
 set(INCLUDE_OUTPUT_PATH include/dso)
 set(CMAKE_OUTPUT_PATH ${LIBRARY_OUTPUT_PATH}/cmake/dso)
+set(PKGCONFIG_OUTPUT_PATH ${LIBRARY_OUTPUT_PATH}/pkgconfig)
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 # required libraries
@@ -33,6 +34,10 @@ set(CMAKE_CXX_FLAGS
 #   "${SSE_FLAGS} -O3 -g -std=c++0x -fno-omit-frame-pointer"
 )
 option(DSO_BUILD_STATIC_LIBRARY        "Build a static dso library, instead of shared" ON)
+
+if(NOT WIN32)
+    option(DSO_BUILD_PKGCONFIG "Build pkg-config .pc file for DSO" ON)
+endif(NOT WIN32)
 
 # Sources files
 set(dso_SOURCE_FILES
@@ -56,7 +61,7 @@ set(dso_SOURCE_FILES
   ${PROJECT_SOURCE_DIR}/src/util/globalCalib.cpp
 )
 
-
+set(DSO_BOOST_LIBRARIES ${Boost_SYSTEM_LIBRARY} ${Boost_THREAD_LIBRARY})
 
 include_directories(
   ${PROJECT_SOURCE_DIR}/src
@@ -153,4 +158,46 @@ install (FILES ${dso_HEADER_FILES} DESTINATION ${INCLUDE_OUTPUT_PATH}/Optimizati
 file(GLOB dso_HEADER_FILES "${PROJECT_SOURCE_DIR}/src/util/*.h")
 
 install (FILES ${dso_HEADER_FILES} DESTINATION ${INCLUDE_OUTPUT_PATH}/util)
+
+macro(libraries_for_pkgconfig VARNAME)
+    foreach(__lib ${ARGN})
+        string(STRIP __lib ${__lib})
+        string(SUBSTRING ${__lib} 0 1 __lib_is_absolute)
+        if (__lib_is_absolute STREQUAL "/")
+            get_filename_component(__lib_path ${__lib} PATH)
+            get_filename_component(__lib_name ${__lib} NAME_WE)
+            string(REGEX REPLACE "^lib" "" __lib_name "${__lib_name}")
+            set(${VARNAME} "${${VARNAME}} -L${__lib_path} -l${__lib_name}")
+        else()
+            set(${VARNAME} "${${VARNAME}} ${__lib}")
+        endif()
+    endforeach()
+endmacro()
+
+# Generate pkgconfig pc file
+if(DSO_BUILD_PKGCONFIG)
+    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/dso.pc.in)
+        message("-- Found: ${CMAKE_CURRENT_SOURCE_DIR}/dso.pc.in")
+
+        # Set the target name
+        set(TARGET_NAME dso)
+
+        # Dependency for DSO
+        libraries_for_pkgconfig(${TARGET_NAME}_PKGCONFIG_LIBS
+            ${DSO_BOOST_LIBRARIES} ${LIBZIP_LIBRARY} ${Pangolin_LIBRARIES}
+            ${OpenCV_LIBS})
+
+        set(${TARGET_NAME}_PKGCONFIG_CFLAGS "${${TARGET_NAME}_PKGCONFIG_CFLAGS} ${BOOST_CFLAGS_OTHER}")
+
+        set(PKGCONFIG_REQUIRES eigen3)
+        set(PKGCONFIG_CFLAGS ${${TARGET_NAME}_PKGCONFIG_CFLAGS})
+        set(PKGCONFIG_LIBS ${${TARGET_NAME}_PKGCONFIG_LIBS})
+
+        configure_file(dso.pc.in dso.pc @ONLY)
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/dso.pc DESTINATION ${PKGCONFIG_OUTPUT_PATH})
+    else()
+        message("-- pkg-config: ${CMAKE_CURRENT_SOURCE_DIR}/dso.pc.in is not available for configuration")
+    endif()
+
+endif(DSO_BUILD_PKGCONFIG)
 

--- a/dso.pc.in
+++ b/dso.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/@LIBRARY_OUTPUT_PATH@
+includedir=${prefix}/@INCLUDE_OUTPUT_PATH@
+
+Name: @TARGET_NAME@
+Description: @TARGET_NAME@
+Version: @DSO_VERSION_STRING@
+Requires: @PKGCONFIG_REQUIRES@
+Libs: -L${libdir} -l@TARGET_NAME@ @PKGCONFIG_LIBS@
+Cflags: -I${includedir} @PKGCONFIG_CFLAGS@


### PR DESCRIPTION
This PR does:
1. option to have a dynamic library. A static library is by default as it was.
`cmake .. -DDSO_BUILD_STATIC_LIBRARY=OFF
`
2. Generation of dso.pc for pkgconfig from dso.pc.in
3. Installation of missing files and using cmake variables.