### PR TITLE
Proper way for closing Pangoling for DSO-ROS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@ find_package(LibZip QUIET)
 find_package(Pangolin 0.2 QUIET)
 find_package(OpenCV QUIET)
 
+#checking for ROS
+find_package(roscpp QUIET)
 
 
 # flags
@@ -30,10 +32,6 @@ set(CMAKE_CXX_FLAGS
    "${SSE_FLAGS} -O3 -g -std=c++0x -march=native"
 #   "${SSE_FLAGS} -O3 -g -std=c++0x -fno-omit-frame-pointer"
 )
-
-if (MSVC)
-     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
-endif (MSVC)
 
 # Sources files
 set(dso_SOURCE_FILES
@@ -65,6 +63,16 @@ include_directories(
   ${EIGEN3_INCLUDE_DIR}
 ) 
 
+# decide if we have ROS
+if(NOT roscpp_FOUND)
+  set(roscpp_LIBRARIES "")
+  message(STATUS "Couldn't find roscpp.")
+else()
+  message(STATUS "Found roscpp installed at ${roscpp_DIR}.")
+  include_directories(${roscpp_INCLUDE_DIRS})
+  add_definitions(-DHAS_ROS=1)
+  
+endif()
 
 # decide if we have pangolin
 if (Pangolin_FOUND)
@@ -120,7 +128,7 @@ add_library(dso ${dso_SOURCE_FILES} ${dso_opencv_SOURCE_FILES} ${dso_pangolin_SO
 if (OpenCV_FOUND AND Pangolin_FOUND)
 	message("--- compiling dso_dataset.")
 	add_executable(dso_dataset ${PROJECT_SOURCE_DIR}/src/main_dso_pangolin.cpp )
-    target_link_libraries(dso_dataset dso boost_system boost_thread cxsparse ${LIBZIP_LIBRARY} ${Pangolin_LIBRARIES} ${OpenCV_LIBS})
+    target_link_libraries(dso_dataset dso boost_system boost_thread cxsparse ${LIBZIP_LIBRARY} ${Pangolin_LIBRARIES} ${OpenCV_LIBS} ${roscpp_LIBRARIES})
 else()
 	message("--- not building dso_dataset, since either don't have openCV or Pangolin.")
 endif()

--- a/src/FullSystem/CoarseInitializer.h
+++ b/src/FullSystem/CoarseInitializer.h
@@ -21,7 +21,7 @@
 * along with DSO. If not, see <http://www.gnu.org/licenses/>.
 */
 
-
+#define EIGEN_ALIGN32 EIGEN_ALIGN_TO_BOUNDARY(32)
 #pragma once
 
 #include "util/NumType.h"
@@ -142,7 +142,7 @@ private:
 			int lvl,
 			Mat88f &H_out, Vec8f &b_out,
 			Mat88f &H_out_sc, Vec8f &b_out_sc,
-			const SE3 &refToNew, AffLight refToNew_aff,
+			SE3 refToNew, AffLight refToNew_aff,
 			bool plot);
 	Vec3f calcEC(int lvl); // returns OLD NERGY, NEW ENERGY, NUM TERMS.
 	void optReg(int lvl);

--- a/src/IOWrapper/Pangolin/PangolinDSOViewer.cpp
+++ b/src/IOWrapper/Pangolin/PangolinDSOViewer.cpp
@@ -32,6 +32,12 @@
 #include "FullSystem/FullSystem.h"
 #include "FullSystem/ImmaturePoint.h"
 
+#include <opencv2/highgui/highgui.hpp>
+
+
+#ifdef HAS_ROS
+	#include <ros/ros.h>
+#endif
 namespace dso
 {
 namespace IOWrap
@@ -291,8 +297,12 @@ void PangolinDSOViewer::run()
 
 	printf("QUIT Pangolin thread!\n");
 	printf("I'll just kill the whole process.\nSo Long, and Thanks for All the Fish!\n");
-
-	exit(1);
+		
+	#ifdef HAS_ROS
+		ros::shutdown();
+	#else
+		exit(1);
+	#endif
 }
 
 

--- a/src/OptimizationBackend/EnergyFunctional.h
+++ b/src/OptimizationBackend/EnergyFunctional.h
@@ -114,11 +114,7 @@ public:
 	IndexThreadReduce<Vec10>* red;
 
 
-	std::map<uint64_t,
-	  Eigen::Vector2i,
-	  std::less<uint64_t>,
-	  Eigen::aligned_allocator<std::pair<uint64_t, Eigen::Vector2i>>
-	  > connectivityMap;
+    std::map<uint64_t,Eigen::Vector2i> connectivityMap;
 
 private:
 


### PR DESCRIPTION
Since this library is going to be used with ROS and withoutROS, it should be compatible for both. 
In the current code, when you close pangolin you are calling exit(0). In the case of using ROS for an online camera, the code after "ros::spin" will never execute unless you call ros::shutdown instead of exit(0) in Pangolin wrapper. 

So unlike running without ROS, in DSO_ROS code, these lines will never execute (line 228-238) when you are using ROS:
```
 for(IOWrap::Output3DWrapper* ow : fullSystem->outputWrapper)
  {
  ow->join();
  delete ow;
  }

  delete undistorter;
  delete fullSystem;

```
I changed the cmake to automatically adapt with ROS such that if it is installed or not. So if a system has ROS, the wrapper will be adaptop for ROS version to use ros:shutdown instead of exit(0).