### PR TITLE
Add SSE2NEON for ARM (Nvidia Tegra, PI, etc) support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "thirdparty/sse2neon"]
+	path = thirdparty/sse2neon
+	url = https://github.com/jratcliff63367/sse2neon.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,6 @@ find_package(LibZip QUIET)
 find_package(Pangolin 0.2 QUIET)
 find_package(OpenCV QUIET)
 
-
-
 # flags
 add_definitions("-DENABLE_SSE")
 set(CMAKE_CXX_FLAGS
@@ -62,6 +60,7 @@ set(dso_SOURCE_FILES
 include_directories(
   ${PROJECT_SOURCE_DIR}/src
   ${PROJECT_SOURCE_DIR}/thirdparty/Sophus
+  ${PROJECT_SOURCE_DIR}/thirdparty/sse2neon
   ${EIGEN3_INCLUDE_DIR}
 ) 
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ to unzip the dataset image archives before loading them).
 	sudo make install
 	sudo cp lib/zipconf.h /usr/local/include/zipconf.h   # (no idea why that is needed).
 
+##### sse2neon (required for ARM builds).
+After cloning, just run `git submodule update --init` to include this.  It translates Intel-native SSE functions to ARM-native NEON functions during the compilation process.
+
 #### 2.3 Build
 
 		cd dso

--- a/src/FullSystem/CoarseInitializer.cpp
+++ b/src/FullSystem/CoarseInitializer.cpp
@@ -37,6 +37,9 @@
 #include "FullSystem/PixelSelector2.h"
 #include "util/nanoflann.h"
 
+#ifndef __SSE3__
+#include "SSE2NEON.h"
+#endif
 
 namespace dso
 {

--- a/src/FullSystem/CoarseTracker.cpp
+++ b/src/FullSystem/CoarseTracker.cpp
@@ -37,6 +37,10 @@
 #include "IOWrapper/ImageRW.h"
 #include <algorithm>
 
+#ifndef __SSE3__
+#include "SSE2NEON.h"
+#endif
+
 namespace dso
 {
 

--- a/src/OptimizationBackend/AccumulatedTopHessian.cpp
+++ b/src/OptimizationBackend/AccumulatedTopHessian.cpp
@@ -27,6 +27,10 @@
 #include "OptimizationBackend/EnergyFunctionalStructs.h"
 #include <iostream>
 
+#ifndef __SSE3__
+#include "SSE2NEON.h"
+#endif
+
 namespace dso
 {
 

--- a/src/OptimizationBackend/EnergyFunctional.cpp
+++ b/src/OptimizationBackend/EnergyFunctional.cpp
@@ -30,7 +30,9 @@
 #include "OptimizationBackend/AccumulatedSCHessian.h"
 #include "OptimizationBackend/AccumulatedTopHessian.h"
 
-
+#ifndef __SSE3__
+#include "SSE2NEON.h"
+#endif
 
 namespace dso
 {

--- a/src/OptimizationBackend/EnergyFunctionalStructs.cpp
+++ b/src/OptimizationBackend/EnergyFunctionalStructs.cpp
@@ -28,7 +28,9 @@
 #include "FullSystem/HessianBlocks.h"
 #include "FullSystem/Residuals.h"
 
-
+#ifndef __SSE3__
+#include "SSE2NEON.h"
+#endif
 
 namespace dso
 {

--- a/src/OptimizationBackend/MatrixAccumulators.h
+++ b/src/OptimizationBackend/MatrixAccumulators.h
@@ -25,6 +25,9 @@
 #pragma once
 #include "util/NumType.h"
 
+#ifndef __SSE3__
+#include "SSE2NEON.h"
+#endif
 
 namespace dso
 {


### PR DESCRIPTION
## What
Adds support for ARM processors.  In my case, this means a quadcopter self-navigating for SAR.  There are a number of possible uses, but in general PI and Nvidia Tegra's seem to run the small robotics world at the moment.

## How
Including SSE2NEON.h only when SSE is not present keeps things nicely segregated - SSE2NEON takes care of all the translations, and any required compatibility fixes would belong to the upstream.  There are other options such as simde; however they didn't work on the very first try :)

## Related issues
#57 and #31

## Changes
I've tried to keep this as loosely-coupled as possible.  Ping me if you'd like any changes, such as just including SSE2NEON.h in the utils folder instead of using the submodule.

Thanks!  Israel