### PR TITLE
Correcting linking error with pthread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,7 @@ add_library(dso ${dso_SOURCE_FILES} ${dso_opencv_SOURCE_FILES} ${dso_pangolin_SO
 if (OpenCV_FOUND AND Pangolin_FOUND)
 	message("--- compiling dso_dataset.")
 	add_executable(dso_dataset ${PROJECT_SOURCE_DIR}/src/main_dso_pangolin.cpp )
-    target_link_libraries(dso_dataset dso boost_system boost_thread cxsparse ${LIBZIP_LIBRARY} ${Pangolin_LIBRARIES} ${OpenCV_LIBS})
+    target_link_libraries(dso_dataset dso boost_system boost_thread cxsparse ${LIBZIP_LIBRARY} ${Pangolin_LIBRARIES} ${OpenCV_LIBS} pthread)
 else()
 	message("--- not building dso_dataset, since either don't have openCV or Pangolin.")
 endif()


### PR DESCRIPTION
On Ubuntu 16.04 with gcc version 5.4.0 the system does not compile with:

`/usr/bin/ld: CMakeFiles/dso_dataset.dir/src/main_dso_pangolin.cpp.o: undefined reference to symbol 'pthread_create@@GLIBC_2.2.5' //lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line collect2: error: ld returned 1 exit status CMakeFiles/dso_dataset.dir/build.make:151: recipe for target 'bin/dso_dataset' failed make[2]: *** [bin/dso_dataset] Error 1 CMakeFiles/Makefile2:67: recipe for target 'CMakeFiles/dso_dataset.dir/all' failed make[1]: *** [CMakeFiles/dso_dataset.dir/all] Error 2 Makefile:83: recipe for target 'all' failed make: *** [all] Error 2`

The proposed commit just explicitly adds pthread library in the linking process.

This is a corrected version of the pull request: https://github.com/JakobEngel/dso/pull/66