### PR TITLE
Fix declarations of aligned allocators.

### DIFF
--- a/src/IOWrapper/Output3DWrapper.h
+++ b/src/IOWrapper/Output3DWrapper.h
@@ -127,7 +127,7 @@ public:
          *  Calling:
          *  Always called, no overhead if not used.
          */
-        virtual void publishGraph(const std::map<uint64_t,Eigen::Vector2i, std::less<uint64_t>, Eigen::aligned_allocator<std::pair<uint64_t, Eigen::Vector2i> > > &connectivity) {}
+        virtual void publishGraph(const std::map<uint64_t,Eigen::Vector2i, std::less<uint64_t>, Eigen::aligned_allocator<std::pair<const uint64_t, Eigen::Vector2i> > > &connectivity) {}
 
 
 

--- a/src/IOWrapper/OutputWrapper/SampleOutputWrapper.h
+++ b/src/IOWrapper/OutputWrapper/SampleOutputWrapper.h
@@ -56,7 +56,7 @@ public:
             printf("OUT: Destroyed SampleOutputWrapper\n");
         }
 
-        virtual void publishGraph(const std::map<uint64_t,Eigen::Vector2i> &connectivity)
+        virtual void publishGraph(const std::map<uint64_t, Eigen::Vector2i, std::less<uint64_t>, Eigen::aligned_allocator<std::pair<const uint64_t, Eigen::Vector2i>>> &connectivity) override
         {
             printf("OUT: got graph with %d edges\n", (int)connectivity.size());
 
@@ -74,7 +74,7 @@ public:
 
 
 
-        virtual void publishKeyframes( std::vector<FrameHessian*> &frames, bool final, CalibHessian* HCalib)
+        virtual void publishKeyframes( std::vector<FrameHessian*> &frames, bool final, CalibHessian* HCalib) override
         {
             for(FrameHessian* f : frames)
             {
@@ -98,7 +98,7 @@ public:
             }
         }
 
-        virtual void publishCamPose(FrameShell* frame, CalibHessian* HCalib)
+        virtual void publishCamPose(FrameShell* frame, CalibHessian* HCalib) override
         {
             printf("OUT: Current Frame %d (time %f, internal ID %d). CameraToWorld:\n",
                    frame->incoming_id,
@@ -108,21 +108,21 @@ public:
         }
 
 
-        virtual void pushLiveFrame(FrameHessian* image)
+        virtual void pushLiveFrame(FrameHessian* image) override
         {
             // can be used to get the raw image / intensity pyramid.
         }
 
-        virtual void pushDepthImage(MinimalImageB3* image)
+        virtual void pushDepthImage(MinimalImageB3* image) override
         {
             // can be used to get the raw image with depth overlay.
         }
-        virtual bool needPushDepthImage()
+        virtual bool needPushDepthImage() override
         {
             return false;
         }
 
-        virtual void pushDepthImageFloat(MinimalImageF* image, FrameHessian* KF )
+        virtual void pushDepthImageFloat(MinimalImageF* image, FrameHessian* KF ) override
         {
             printf("OUT: Predicted depth for KF %d (id %d, time %f, internal frame-ID %d). CameraToWorld:\n",
                    KF->frameID,

--- a/src/IOWrapper/Pangolin/PangolinDSOViewer.cpp
+++ b/src/IOWrapper/Pangolin/PangolinDSOViewer.cpp
@@ -419,7 +419,7 @@ void PangolinDSOViewer::drawConstraints()
 
 
 
-void PangolinDSOViewer::publishGraph(const std::map<uint64_t,Eigen::Vector2i> &connectivity)
+void PangolinDSOViewer::publishGraph(const std::map<uint64_t, Eigen::Vector2i, std::less<uint64_t>, Eigen::aligned_allocator<std::pair<const uint64_t, Eigen::Vector2i>>> &connectivity)
 {
     if(!setting_render_display3D) return;
     if(disableAllDisplay) return;

--- a/src/IOWrapper/Pangolin/PangolinDSOViewer.h
+++ b/src/IOWrapper/Pangolin/PangolinDSOViewer.h
@@ -67,18 +67,18 @@ public:
 
 
 	// ==================== Output3DWrapper Functionality ======================
-    virtual void publishGraph(const std::map<uint64_t,Eigen::Vector2i> &connectivity);
-    virtual void publishKeyframes( std::vector<FrameHessian*> &frames, bool final, CalibHessian* HCalib);
-    virtual void publishCamPose(FrameShell* frame, CalibHessian* HCalib);
+    virtual void publishGraph(const std::map<uint64_t, Eigen::Vector2i, std::less<uint64_t>, Eigen::aligned_allocator<std::pair<const uint64_t, Eigen::Vector2i>>> &connectivity) override;
+    virtual void publishKeyframes( std::vector<FrameHessian*> &frames, bool final, CalibHessian* HCalib) override;
+    virtual void publishCamPose(FrameShell* frame, CalibHessian* HCalib) override;
 
 
-	virtual void pushLiveFrame(FrameHessian* image);
-	virtual void pushDepthImage(MinimalImageB3* image);
-    virtual bool needPushDepthImage();
+    virtual void pushLiveFrame(FrameHessian* image) override;
+    virtual void pushDepthImage(MinimalImageB3* image) override;
+    virtual bool needPushDepthImage() override;
 
-	virtual void join();
+    virtual void join() override;
 
-	virtual void reset();
+    virtual void reset() override;
 private:
 
 	bool needReset;

--- a/src/OptimizationBackend/EnergyFunctional.h
+++ b/src/OptimizationBackend/EnergyFunctional.h
@@ -117,7 +117,7 @@ public:
 	std::map<uint64_t,
 	  Eigen::Vector2i,
 	  std::less<uint64_t>,
-	  Eigen::aligned_allocator<std::pair<uint64_t, Eigen::Vector2i>>
+	  Eigen::aligned_allocator<std::pair<const uint64_t, Eigen::Vector2i>>
 	  > connectivityMap;
 
 private:


### PR DESCRIPTION
Fixes #111. It seems like you need a `const` for the first argument of a
`std::pair` in `aligned_allocator` to make xcode 9 happy.

Fix the override of `PangolinDSOViewer::publishGraph`. Without this patch, the display of constraints does not work as it used to.

Added some `override` statements to Output3DWrapper's derived classes, to avoid such problems in the future.