### PR TITLE
Switch to C++11 Standard and remove boost dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,13 +25,16 @@ find_package(OpenCV QUIET)
 # flags
 add_definitions("-DENABLE_SSE")
 set(CMAKE_CXX_FLAGS
-   "${SSE_FLAGS} -O3 -g -std=c++0x -march=native"
+   "${SSE_FLAGS} -O3 -g -march=native"
 #   "${SSE_FLAGS} -O3 -g -std=c++0x -fno-omit-frame-pointer"
 )
 
 if (MSVC)
      set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
 endif (MSVC)
+
+# use c++11 standard
+set (CMAKE_CXX_STANDARD 11)
 
 # Sources files
 set(dso_SOURCE_FILES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,6 @@ set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 # required libraries
 find_package(SuiteParse REQUIRED)
 find_package(Eigen3 REQUIRED)
-find_package(Boost COMPONENTS system thread) 
 
 # optional libraries
 find_package(LibZip QUIET)
@@ -117,18 +116,11 @@ add_library(dso ${dso_SOURCE_FILES} ${dso_opencv_SOURCE_FILES} ${dso_pangolin_SO
 
 #set_property( TARGET dso APPEND_STRING PROPERTY COMPILE_FLAGS -Wall )
 
-
-if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin") # OSX
-    set(BOOST_THREAD_LIBRARY boost_thread-mt)
-else()
-    set(BOOST_THREAD_LIBRARY boost_thread)
-endif()
-
 # build main executable (only if we have both OpenCV and Pangolin)
 if (OpenCV_FOUND AND Pangolin_FOUND)
 	message("--- compiling dso_dataset.")
 	add_executable(dso_dataset ${PROJECT_SOURCE_DIR}/src/main_dso_pangolin.cpp )
-    target_link_libraries(dso_dataset dso boost_system cxsparse ${BOOST_THREAD_LIBRARY} ${LIBZIP_LIBRARY} ${Pangolin_LIBRARIES} ${OpenCV_LIBS})
+    target_link_libraries(dso_dataset dso cxsparse ${LIBZIP_LIBRARY} ${Pangolin_LIBRARIES} ${OpenCV_LIBS})
 else()
 	message("--- not building dso_dataset, since either don't have openCV or Pangolin.")
 endif()

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Get some datasets from [https://vision.in.tum.de/mono-dataset](https://vision.in
 ##### suitesparse and eigen3 (required).
 Required. Install with
 
-		sudo apt-get install libsuitesparse-dev libeigen3-dev libboost-all-dev
+		sudo apt-get install libsuitesparse-dev libeigen3-dev
 
 
 

--- a/src/FullSystem/FullSystem.cpp
+++ b/src/FullSystem/FullSystem.cpp
@@ -1026,6 +1026,8 @@ void FullSystem::blockUntilMappingIsFinished()
 {
 	{
 		std::unique_lock<std::mutex> lock(trackMapSyncMutex);
+		// check if mapping thread already down
+		if (!runMapping) { return; }
 		runMapping = false;
 		trackedFrameSignal.notify_all();
 	}

--- a/src/FullSystem/FullSystem.cpp
+++ b/src/FullSystem/FullSystem.cpp
@@ -55,6 +55,7 @@
 #include "util/ImageAndExposure.h"
 
 #include <cmath>
+#include <iomanip>
 
 namespace dso
 {
@@ -164,7 +165,7 @@ FullSystem::FullSystem()
 
 	linearizeOperation=true;
 	runMapping=true;
-	mappingThread = boost::thread(&FullSystem::mappingLoop, this);
+	mappingThread = std::thread(&FullSystem::mappingLoop, this);
 	lastRefStopID=0;
 
 
@@ -244,8 +245,8 @@ void FullSystem::setGammaFunction(float* BInv)
 
 void FullSystem::printResult(std::string file)
 {
-	boost::unique_lock<boost::mutex> lock(trackMutex);
-	boost::unique_lock<boost::mutex> crlock(shellPoseMutex);
+	std::unique_lock<std::mutex> lock(trackMutex);
+	std::unique_lock<std::mutex> crlock(shellPoseMutex);
 
 	std::ofstream myfile;
 	myfile.open (file.c_str());
@@ -293,7 +294,7 @@ Vec4 FullSystem::trackNewCoarse(FrameHessian* fh)
 		SE3 slast_2_sprelast;
 		SE3 lastF_2_slast;
 		{	// lock on global pose consistency!
-			boost::unique_lock<boost::mutex> crlock(shellPoseMutex);
+			std::unique_lock<std::mutex> crlock(shellPoseMutex);
 			slast_2_sprelast = sprelast->camToWorld.inverse() * slast->camToWorld;
 			lastF_2_slast = slast->camToWorld.inverse() * lastF->shell->camToWorld;
 			aff_last_2_l = slast->aff_g2l;
@@ -462,7 +463,7 @@ Vec4 FullSystem::trackNewCoarse(FrameHessian* fh)
 
 void FullSystem::traceNewCoarse(FrameHessian* fh)
 {
-	boost::unique_lock<boost::mutex> lock(mapMutex);
+	std::unique_lock<std::mutex> lock(mapMutex);
 
 	int trace_total=0, trace_good=0, trace_oob=0, trace_out=0, trace_skip=0, trace_badcondition=0, trace_uninitialized=0;
 
@@ -643,7 +644,15 @@ void FullSystem::activatePointsMT()
 	std::vector<PointHessian*> optimized; optimized.resize(toOptimize.size());
 
 	if(multiThreading)
-		treadReduce.reduce(boost::bind(&FullSystem::activatePointsMT_Reductor, this, &optimized, &toOptimize, _1, _2, _3, _4), 0, toOptimize.size(), 50);
+		treadReduce.reduce(
+				std::bind(&FullSystem::activatePointsMT_Reductor,
+					this,
+					&optimized,
+					&toOptimize,
+					std::placeholders::_1,
+					std::placeholders::_2,
+					std::placeholders::_3,
+					std::placeholders::_4), 0, toOptimize.size(), 50);
 
 	else
 		activatePointsMT_Reductor(&optimized, &toOptimize, 0, toOptimize.size(), 0, 0);
@@ -803,7 +812,7 @@ void FullSystem::addActiveFrame( ImageAndExposure* image, int id )
 {
 
     if(isLost) return;
-	boost::unique_lock<boost::mutex> lock(trackMutex);
+	std::unique_lock<std::mutex> lock(trackMutex);
 
 
 	// =========================== add into allFrameHistory =========================
@@ -853,7 +862,7 @@ void FullSystem::addActiveFrame( ImageAndExposure* image, int id )
 		// =========================== SWAP tracking reference?. =========================
 		if(coarseTracker_forNewKF->refFrameID > coarseTracker->refFrameID)
 		{
-			boost::unique_lock<boost::mutex> crlock(coarseTrackerSwapMutex);
+			std::unique_lock<std::mutex> crlock(coarseTrackerSwapMutex);
 			CoarseTracker* tmp = coarseTracker; coarseTracker=coarseTracker_forNewKF; coarseTracker_forNewKF=tmp;
 		}
 
@@ -928,7 +937,7 @@ void FullSystem::deliverTrackedFrame(FrameHessian* fh, bool needKF)
 	}
 	else
 	{
-		boost::unique_lock<boost::mutex> lock(trackMapSyncMutex);
+		std::unique_lock<std::mutex> lock(trackMapSyncMutex);
 		unmappedTrackedFrames.push_back(fh);
 		if(needKF) needNewKFAfter=fh->shell->trackingRef->id;
 		trackedFrameSignal.notify_all();
@@ -944,7 +953,7 @@ void FullSystem::deliverTrackedFrame(FrameHessian* fh, bool needKF)
 
 void FullSystem::mappingLoop()
 {
-	boost::unique_lock<boost::mutex> lock(trackMapSyncMutex);
+	std::unique_lock<std::mutex> lock(trackMapSyncMutex);
 
 	while(runMapping)
 	{
@@ -983,7 +992,7 @@ void FullSystem::mappingLoop()
 				FrameHessian* fh = unmappedTrackedFrames.front();
 				unmappedTrackedFrames.pop_front();
 				{
-					boost::unique_lock<boost::mutex> crlock(shellPoseMutex);
+					std::unique_lock<std::mutex> crlock(shellPoseMutex);
 					assert(fh->shell->trackingRef != 0);
 					fh->shell->camToWorld = fh->shell->trackingRef->camToWorld * fh->shell->camToTrackingRef;
 					fh->setEvalPT_scaled(fh->shell->camToWorld.inverse(),fh->shell->aff_g2l);
@@ -1015,10 +1024,11 @@ void FullSystem::mappingLoop()
 
 void FullSystem::blockUntilMappingIsFinished()
 {
-	boost::unique_lock<boost::mutex> lock(trackMapSyncMutex);
-	runMapping = false;
-	trackedFrameSignal.notify_all();
-	lock.unlock();
+	{
+		std::unique_lock<std::mutex> lock(trackMapSyncMutex);
+		runMapping = false;
+		trackedFrameSignal.notify_all();
+	}
 
 	mappingThread.join();
 
@@ -1028,7 +1038,7 @@ void FullSystem::makeNonKeyFrame( FrameHessian* fh)
 {
 	// needs to be set by mapping thread. no lock required since we are in mapping thread.
 	{
-		boost::unique_lock<boost::mutex> crlock(shellPoseMutex);
+		std::unique_lock<std::mutex> crlock(shellPoseMutex);
 		assert(fh->shell->trackingRef != 0);
 		fh->shell->camToWorld = fh->shell->trackingRef->camToWorld * fh->shell->camToTrackingRef;
 		fh->setEvalPT_scaled(fh->shell->camToWorld.inverse(),fh->shell->aff_g2l);
@@ -1042,7 +1052,7 @@ void FullSystem::makeKeyFrame( FrameHessian* fh)
 {
 	// needs to be set by mapping thread
 	{
-		boost::unique_lock<boost::mutex> crlock(shellPoseMutex);
+		std::unique_lock<std::mutex> crlock(shellPoseMutex);
 		assert(fh->shell->trackingRef != 0);
 		fh->shell->camToWorld = fh->shell->trackingRef->camToWorld * fh->shell->camToTrackingRef;
 		fh->setEvalPT_scaled(fh->shell->camToWorld.inverse(),fh->shell->aff_g2l);
@@ -1050,7 +1060,7 @@ void FullSystem::makeKeyFrame( FrameHessian* fh)
 
 	traceNewCoarse(fh);
 
-	boost::unique_lock<boost::mutex> lock(mapMutex);
+	std::unique_lock<std::mutex> lock(mapMutex);
 
 	// =========================== Flag Frames to be Marginalized. =========================
 	flagFramesForMarginalization(fh);
@@ -1137,7 +1147,7 @@ void FullSystem::makeKeyFrame( FrameHessian* fh)
 
 
 	{
-		boost::unique_lock<boost::mutex> crlock(coarseTrackerSwapMutex);
+		std::unique_lock<std::mutex> crlock(coarseTrackerSwapMutex);
 		coarseTracker_forNewKF->makeK(&Hcalib);
 		coarseTracker_forNewKF->setCoarseTrackingRef(frameHessians);
 
@@ -1198,7 +1208,7 @@ void FullSystem::makeKeyFrame( FrameHessian* fh)
 
 void FullSystem::initializeFromInitializer(FrameHessian* newFrame)
 {
-	boost::unique_lock<boost::mutex> lock(mapMutex);
+	std::unique_lock<std::mutex> lock(mapMutex);
 
 	// add firstframe.
 	FrameHessian* firstFrame = coarseInitializer->firstFrame;
@@ -1264,7 +1274,7 @@ void FullSystem::initializeFromInitializer(FrameHessian* newFrame)
 
 	// really no lock required, as we are initializing.
 	{
-		boost::unique_lock<boost::mutex> crlock(shellPoseMutex);
+		std::unique_lock<std::mutex> crlock(shellPoseMutex);
 		firstFrame->shell->camToWorld = SE3();
 		firstFrame->shell->aff_g2l = AffLight(0,0);
 		firstFrame->setEvalPT_scaled(firstFrame->shell->camToWorld.inverse(),firstFrame->shell->aff_g2l);
@@ -1460,7 +1470,7 @@ void FullSystem::printFrameLifetimes()
 	if(!setting_logStuff) return;
 
 
-	boost::unique_lock<boost::mutex> lock(trackMutex);
+	std::unique_lock<std::mutex> lock(trackMutex);
 
 	std::ofstream* lg = new std::ofstream();
 	lg->open("logs/lifetimeLog.txt", std::ios::trunc | std::ios::out);

--- a/src/FullSystem/FullSystem.h
+++ b/src/FullSystem/FullSystem.h
@@ -25,7 +25,10 @@
 #pragma once
 #define MAX_ACTIVE_FRAMES 100
 
+#include <condition_variable>
 #include <deque>
+#include <mutex>
+
 #include "util/NumType.h"
 #include "util/globalCalib.h"
 #include "vector"
@@ -252,14 +255,14 @@ private:
 
 
 	// =================== changed by tracker-thread. protected by trackMutex ============
-	boost::mutex trackMutex;
+	std::mutex trackMutex;
 	std::vector<FrameShell*> allFrameHistory;
 	CoarseInitializer* coarseInitializer;
 	Vec5 lastCoarseRMSE;
 
 
 	// ================== changed by mapper-thread. protected by mapMutex ===============
-	boost::mutex mapMutex;
+	std::mutex mapMutex;
 	std::vector<FrameShell*> allKeyFramesHistory;
 
 	EnergyFunctional* ef;
@@ -279,7 +282,7 @@ private:
 
 
 	// mutex etc. for tracker exchange.
-	boost::mutex coarseTrackerSwapMutex;			// if tracker sees that there is a new reference, tracker locks [coarseTrackerSwapMutex] and swaps the two.
+	std::mutex coarseTrackerSwapMutex;			// if tracker sees that there is a new reference, tracker locks [coarseTrackerSwapMutex] and swaps the two.
 	CoarseTracker* coarseTracker_forNewKF;			// set as as reference. protected by [coarseTrackerSwapMutex].
 	CoarseTracker* coarseTracker;					// always used to track new frames. protected by [trackMutex].
 	float minIdJetVisTracker, maxIdJetVisTracker;
@@ -290,7 +293,7 @@ private:
 
 
 	// mutex for camToWorl's in shells (these are always in a good configuration).
-	boost::mutex shellPoseMutex;
+	std::mutex shellPoseMutex;
 
 
 
@@ -305,12 +308,12 @@ private:
 	void mappingLoop();
 
 	// tracking / mapping synchronization. All protected by [trackMapSyncMutex].
-	boost::mutex trackMapSyncMutex;
-	boost::condition_variable trackedFrameSignal;
-	boost::condition_variable mappedFrameSignal;
+	std::mutex trackMapSyncMutex;
+	std::condition_variable trackedFrameSignal;
+	std::condition_variable mappedFrameSignal;
 	std::deque<FrameHessian*> unmappedTrackedFrames;
 	int needNewKFAfter;	// Otherwise, a new KF is *needed that has ID bigger than [needNewKFAfter]*.
-	boost::thread mappingThread;
+	std::thread mappingThread;
 	bool runMapping;
 	bool needToKetchupMapping;
 

--- a/src/FullSystem/FullSystemOptimize.cpp
+++ b/src/FullSystem/FullSystemOptimize.cpp
@@ -151,7 +151,12 @@ Vec3 FullSystem::linearizeAll(bool fixLinearization)
 
 	if(multiThreading)
 	{
-		treadReduce.reduce(boost::bind(&FullSystem::linearizeAll_Reductor, this, fixLinearization, toRemove, _1, _2, _3, _4), 0, activeResiduals.size(), 0);
+		treadReduce.reduce(std::bind(&FullSystem::linearizeAll_Reductor,
+					this, fixLinearization, toRemove,
+					std::placeholders::_1,
+					std::placeholders::_2,
+					std::placeholders::_3,
+					std::placeholders::_4), 0, activeResiduals.size(), 0);
 		lastEnergyP = treadReduce.stats[0];
 	}
 	else
@@ -451,7 +456,12 @@ float FullSystem::optimize(int mnumOptIts)
 
 
 	if(multiThreading)
-		treadReduce.reduce(boost::bind(&FullSystem::applyRes_Reductor, this, true, _1, _2, _3, _4), 0, activeResiduals.size(), 50);
+		treadReduce.reduce(std::bind(&FullSystem::applyRes_Reductor,
+					this, true,
+					std::placeholders::_1,
+					std::placeholders::_2,
+					std::placeholders::_3,
+					std::placeholders::_4), 0, activeResiduals.size(), 50);
 	else
 		applyRes_Reductor(true,0,activeResiduals.size(),0,0);
 
@@ -522,7 +532,13 @@ float FullSystem::optimize(int mnumOptIts)
 		{
 
 			if(multiThreading)
-				treadReduce.reduce(boost::bind(&FullSystem::applyRes_Reductor, this, true, _1, _2, _3, _4), 0, activeResiduals.size(), 50);
+				treadReduce.reduce(std::bind(&FullSystem::applyRes_Reductor,
+							this,
+							true,
+							std::placeholders::_1,
+							std::placeholders::_2,
+							std::placeholders::_3,
+							std::placeholders::_4), 0, activeResiduals.size(), 50);
 			else
 				applyRes_Reductor(true,0,activeResiduals.size(),0,0);
 
@@ -584,7 +600,7 @@ float FullSystem::optimize(int mnumOptIts)
 	}
 
 	{
-		boost::unique_lock<boost::mutex> crlock(shellPoseMutex);
+		std::unique_lock<std::mutex> crlock(shellPoseMutex);
 		for(FrameHessian* fh : frameHessians)
 		{
 			fh->shell->camToWorld = fh->PRE_camToWorld;

--- a/src/IOWrapper/OpenCV/ImageDisplay_OpenCV.cpp
+++ b/src/IOWrapper/OpenCV/ImageDisplay_OpenCV.cpp
@@ -27,10 +27,10 @@
 
 #include <opencv2/highgui/highgui.hpp>
 
+#include <mutex>
 #include <string>
 #include <unordered_set>
 
-#include <boost/thread.hpp>
 
 #include "util/settings.h"
 
@@ -42,7 +42,7 @@ namespace IOWrap
 {
 
 std::unordered_set<std::string> openWindows;
-boost::mutex openCVdisplayMutex;
+std::mutex openCVdisplayMutex;
 
 
 
@@ -50,7 +50,7 @@ void displayImage(const char* windowName, const cv::Mat& image, bool autoSize)
 {
 	if(disableAllDisplay) return;
 
-	boost::unique_lock<boost::mutex> lock(openCVdisplayMutex);
+	std::unique_lock<std::mutex> lock(openCVdisplayMutex);
 	if(!autoSize)
 	{
 		if(openWindows.find(windowName) == openWindows.end())
@@ -181,14 +181,14 @@ int waitKey(int milliseconds)
 {
 	if(disableAllDisplay) return 0;
 
-	boost::unique_lock<boost::mutex> lock(openCVdisplayMutex);
+	std::unique_lock<std::mutex> lock(openCVdisplayMutex);
 	return cv::waitKey(milliseconds);
 }
 
 void closeAllWindows()
 {
 	if(disableAllDisplay) return;
-	boost::unique_lock<boost::mutex> lock(openCVdisplayMutex);
+	std::unique_lock<std::mutex> lock(openCVdisplayMutex);
 	cv::destroyAllWindows();
 	openWindows.clear();
 }

--- a/src/IOWrapper/OutputWrapper/SampleOutputWrapper.h
+++ b/src/IOWrapper/OutputWrapper/SampleOutputWrapper.h
@@ -23,7 +23,6 @@
 
 
 #pragma once
-#include "boost/thread.hpp"
 #include "util/MinimalImage.h"
 #include "IOWrapper/Output3DWrapper.h"
 

--- a/src/IOWrapper/Pangolin/PangolinDSOViewer.cpp
+++ b/src/IOWrapper/Pangolin/PangolinDSOViewer.cpp
@@ -32,6 +32,8 @@
 #include "FullSystem/FullSystem.h"
 #include "FullSystem/ImmaturePoint.h"
 
+#include <sys/time.h>
+
 namespace dso
 {
 namespace IOWrap
@@ -47,7 +49,7 @@ PangolinDSOViewer::PangolinDSOViewer(int w, int h, bool startRunThread)
 
 
 	{
-		boost::unique_lock<boost::mutex> lk(openImagesMutex);
+		std::unique_lock<std::mutex> lk(openImagesMutex);
 		internalVideoImg = new MinimalImageB3(w,h);
 		internalKFImg = new MinimalImageB3(w,h);
 		internalResImg = new MinimalImageB3(w,h);
@@ -67,7 +69,7 @@ PangolinDSOViewer::PangolinDSOViewer(int w, int h, bool startRunThread)
 
 
     if(startRunThread)
-        runThread = boost::thread(&PangolinDSOViewer::run, this);
+        runThread = std::thread(&PangolinDSOViewer::run, this);
 
 }
 
@@ -173,7 +175,7 @@ void PangolinDSOViewer::run()
 		{
 			// Activate efficiently by object
 			Visualization3D_display.Activate(Visualization3D_camera);
-			boost::unique_lock<boost::mutex> lk3d(model3DMutex);
+			std::unique_lock<std::mutex> lk3d(model3DMutex);
 			//pangolin::glDrawColouredCube();
 			int refreshed=0;
 			for(KeyFrameDisplay* fh : keyframes)
@@ -471,7 +473,7 @@ void PangolinDSOViewer::publishKeyframes(
 	if(!setting_render_display3D) return;
     if(disableAllDisplay) return;
 
-	boost::unique_lock<boost::mutex> lk(model3DMutex);
+	std::unique_lock<std::mutex> lk(model3DMutex);
 	for(FrameHessian* fh : frames)
 	{
 		if(keyframesByKFID.find(fh->frameID) == keyframesByKFID.end())
@@ -489,7 +491,7 @@ void PangolinDSOViewer::publishCamPose(FrameShell* frame,
     if(!setting_render_display3D) return;
     if(disableAllDisplay) return;
 
-	boost::unique_lock<boost::mutex> lk(model3DMutex);
+	std::unique_lock<std::mutex> lk(model3DMutex);
 	struct timeval time_now;
 	gettimeofday(&time_now, NULL);
 	lastNTrackingMs.push_back(((time_now.tv_sec-last_track.tv_sec)*1000.0f + (time_now.tv_usec-last_track.tv_usec)/1000.0f));
@@ -508,7 +510,7 @@ void PangolinDSOViewer::pushLiveFrame(FrameHessian* image)
 	if(!setting_render_displayVideo) return;
     if(disableAllDisplay) return;
 
-	boost::unique_lock<boost::mutex> lk(openImagesMutex);
+	std::unique_lock<std::mutex> lk(openImagesMutex);
 
 	for(int i=0;i<w*h;i++)
 		internalVideoImg->data[i][0] =
@@ -529,7 +531,7 @@ void PangolinDSOViewer::pushDepthImage(MinimalImageB3* image)
     if(!setting_render_displayDepth) return;
     if(disableAllDisplay) return;
 
-	boost::unique_lock<boost::mutex> lk(openImagesMutex);
+	std::unique_lock<std::mutex> lk(openImagesMutex);
 
 	struct timeval time_now;
 	gettimeofday(&time_now, NULL);

--- a/src/IOWrapper/Pangolin/PangolinDSOViewer.h
+++ b/src/IOWrapper/Pangolin/PangolinDSOViewer.h
@@ -23,8 +23,10 @@
 
 
 #pragma once
+#include <thread>
+#include <mutex>
+
 #include <pangolin/pangolin.h>
-#include "boost/thread.hpp"
 #include "util/MinimalImage.h"
 #include "IOWrapper/Output3DWrapper.h"
 #include <map>
@@ -85,14 +87,14 @@ private:
 	void reset_internal();
 	void drawConstraints();
 
-	boost::thread runThread;
+	std::thread runThread;
 	bool running;
 	int w,h;
 
 
 
 	// images rendering
-	boost::mutex openImagesMutex;
+	std::mutex openImagesMutex;
 	MinimalImageB3* internalVideoImg;
 	MinimalImageB3* internalKFImg;
 	MinimalImageB3* internalResImg;
@@ -101,7 +103,7 @@ private:
 
 
 	// 3D model rendering
-	boost::mutex model3DMutex;
+	std::mutex model3DMutex;
 	KeyFrameDisplay* currentCam;
 	std::vector<KeyFrameDisplay*> keyframes;
 	std::vector<Vec3f,Eigen::aligned_allocator<Vec3f>> allFramePoses;

--- a/src/OptimizationBackend/AccumulatedSCHessian.h
+++ b/src/OptimizationBackend/AccumulatedSCHessian.h
@@ -104,8 +104,12 @@ public:
 				bs[i] = VecX::Zero(nframes[0]*8+CPARS);
 			}
 
-			red->reduce(boost::bind(&AccumulatedSCHessianSSE::stitchDoubleInternal,
-				this,Hs, bs, EF,  _1, _2, _3, _4), 0, nframes[0]*nframes[0], 0);
+			red->reduce(std::bind(&AccumulatedSCHessianSSE::stitchDoubleInternal,
+				this,Hs, bs, EF,
+				std::placeholders::_1,
+				std::placeholders::_2,
+				std::placeholders::_3,
+				std::placeholders::_4), 0, nframes[0]*nframes[0], 0);
 
 			// sum up results
 			H = Hs[0];

--- a/src/OptimizationBackend/AccumulatedTopHessian.h
+++ b/src/OptimizationBackend/AccumulatedTopHessian.h
@@ -102,8 +102,12 @@ public:
 				bs[i] = VecX::Zero(nframes[0]*8+CPARS);
 			}
 
-			red->reduce(boost::bind(&AccumulatedTopHessianSSE::stitchDoubleInternal,
-				this,Hs, bs, EF, usePrior,  _1, _2, _3, _4), 0, nframes[0]*nframes[0], 0);
+			red->reduce(std::bind(&AccumulatedTopHessianSSE::stitchDoubleInternal,
+				this,Hs, bs, EF, usePrior,
+				std::placeholders::_1,
+				std::placeholders::_2,
+				std::placeholders::_3,
+				std::placeholders::_4), 0, nframes[0]*nframes[0], 0);
 
 			// sum up results
 			H = Hs[0];

--- a/src/OptimizationBackend/EnergyFunctional.cpp
+++ b/src/OptimizationBackend/EnergyFunctional.cpp
@@ -198,9 +198,17 @@ void EnergyFunctional::accumulateAF_MT(MatXX &H, VecX &b, bool MT)
 {
 	if(MT)
 	{
-		red->reduce(boost::bind(&AccumulatedTopHessianSSE::setZero, accSSE_top_A, nFrames,  _1, _2, _3, _4), 0, 0, 0);
-		red->reduce(boost::bind(&AccumulatedTopHessianSSE::addPointsInternal<0>,
-				accSSE_top_A, &allPoints, this,  _1, _2, _3, _4), 0, allPoints.size(), 50);
+		red->reduce(std::bind(&AccumulatedTopHessianSSE::setZero, accSSE_top_A, nFrames,
+					std::placeholders::_1,
+					std::placeholders::_2,
+					std::placeholders::_3,
+					std::placeholders::_4), 0, 0, 0);
+		red->reduce(std::bind(&AccumulatedTopHessianSSE::addPointsInternal<0>,
+				accSSE_top_A, &allPoints, this,
+				std::placeholders::_1,
+				std::placeholders::_2,
+				std::placeholders::_3,
+				std::placeholders::_4), 0, allPoints.size(), 50);
 		accSSE_top_A->stitchDoubleMT(red,H,b,this,false,true);
 		resInA = accSSE_top_A->nres[0];
 	}
@@ -220,9 +228,17 @@ void EnergyFunctional::accumulateLF_MT(MatXX &H, VecX &b, bool MT)
 {
 	if(MT)
 	{
-		red->reduce(boost::bind(&AccumulatedTopHessianSSE::setZero, accSSE_top_L, nFrames,  _1, _2, _3, _4), 0, 0, 0);
-		red->reduce(boost::bind(&AccumulatedTopHessianSSE::addPointsInternal<1>,
-				accSSE_top_L, &allPoints, this,  _1, _2, _3, _4), 0, allPoints.size(), 50);
+		red->reduce(std::bind(&AccumulatedTopHessianSSE::setZero, accSSE_top_L, nFrames,
+					std::placeholders::_1,
+					std::placeholders::_2,
+					std::placeholders::_3,
+					std::placeholders::_4), 0, 0, 0);
+		red->reduce(std::bind(&AccumulatedTopHessianSSE::addPointsInternal<1>,
+				accSSE_top_L, &allPoints, this,
+				std::placeholders::_1,
+				std::placeholders::_2,
+				std::placeholders::_3,
+				std::placeholders::_4), 0, allPoints.size(), 50);
 		accSSE_top_L->stitchDoubleMT(red,H,b,this,true,true);
 		resInL = accSSE_top_L->nres[0];
 	}
@@ -245,9 +261,17 @@ void EnergyFunctional::accumulateSCF_MT(MatXX &H, VecX &b, bool MT)
 {
 	if(MT)
 	{
-		red->reduce(boost::bind(&AccumulatedSCHessianSSE::setZero, accSSE_bot, nFrames,  _1, _2, _3, _4), 0, 0, 0);
-		red->reduce(boost::bind(&AccumulatedSCHessianSSE::addPointsInternal,
-				accSSE_bot, &allPoints, true,  _1, _2, _3, _4), 0, allPoints.size(), 50);
+		red->reduce(std::bind(&AccumulatedSCHessianSSE::setZero, accSSE_bot, nFrames,
+					std::placeholders::_1,
+					std::placeholders::_2,
+					std::placeholders::_3,
+					std::placeholders::_4), 0, 0, 0);
+		red->reduce(std::bind(&AccumulatedSCHessianSSE::addPointsInternal,
+				accSSE_bot, &allPoints, true,
+				std::placeholders::_1,
+				std::placeholders::_2,
+				std::placeholders::_3,
+				std::placeholders::_4), 0, allPoints.size(), 50);
 		accSSE_bot->stitchDoubleMT(red,H,b,this,true);
 	}
 	else
@@ -280,8 +304,12 @@ void EnergyFunctional::resubstituteF_MT(VecX x, CalibHessian* HCalib, bool MT)
 	}
 
 	if(MT)
-		red->reduce(boost::bind(&EnergyFunctional::resubstituteFPt,
-						this, cstep, xAd,  _1, _2, _3, _4), 0, allPoints.size(), 50);
+		red->reduce(std::bind(&EnergyFunctional::resubstituteFPt,
+						this, cstep, xAd,
+						std::placeholders::_1,
+						std::placeholders::_2,
+						std::placeholders::_3,
+						std::placeholders::_4), 0, allPoints.size(), 50);
 	else
 		resubstituteFPt(cstep, xAd, 0, allPoints.size(), 0,0);
 
@@ -406,8 +434,12 @@ double EnergyFunctional::calcLEnergyF_MT()
 
 	E += cDeltaF.cwiseProduct(cPriorF).dot(cDeltaF);
 
-	red->reduce(boost::bind(&EnergyFunctional::calcLEnergyPt,
-			this, _1, _2, _3, _4), 0, allPoints.size(), 50);
+	red->reduce(std::bind(&EnergyFunctional::calcLEnergyPt,
+			this,
+			std::placeholders::_1,
+			std::placeholders::_2,
+			std::placeholders::_3,
+			std::placeholders::_4), 0, allPoints.size(), 50);
 
 	return E+red->stats[0];
 }

--- a/src/main_dso_pangolin.cpp
+++ b/src/main_dso_pangolin.cpp
@@ -29,12 +29,12 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
+#include <sys/time.h>
 
 #include "IOWrapper/Output3DWrapper.h"
 #include "IOWrapper/ImageDisplay.h"
 
 
-#include <boost/thread.hpp>
 #include "util/settings.h"
 #include "util/globalFuncs.h"
 #include "util/DatasetReader.h"
@@ -358,7 +358,7 @@ int main( int argc, char** argv )
 		parseArgument(argv[i]);
 
 	// hook crtl+C.
-	boost::thread exThread = boost::thread(exitThread);
+	std::thread exThread(exitThread);
 
 
 	ImageFolderReader* reader = new ImageFolderReader(source,calib, gammaCalib, vignette);

--- a/src/main_dso_pangolin.cpp
+++ b/src/main_dso_pangolin.cpp
@@ -23,6 +23,7 @@
 
 
 
+#include <atomic>
 #include <thread>
 #include <locale.h>
 #include <signal.h>
@@ -65,6 +66,8 @@ float playbackSpeed=0;	// 0 for linearize (play as fast as possible, while seque
 bool preload=false;
 bool useSampleOutput=false;
 
+std::atomic<bool> exThreadKeepRunning(true);
+
 
 int mode=0;
 
@@ -88,7 +91,9 @@ void exitThread()
 	sigaction(SIGINT, &sigIntHandler, NULL);
 
 	firstRosSpin=true;
-	while(true) pause();
+	while(exThreadKeepRunning) {
+		std::this_thread::sleep_for (std::chrono::milliseconds(10));
+	}
 }
 
 
@@ -582,6 +587,10 @@ int main( int argc, char** argv )
 
 	printf("DELETE READER!\n");
 	delete reader;
+
+	// shutdown exThread
+	exThreadKeepRunning = false;
+	exThread.join();
 
 	printf("EXIT NOW!\n");
 	return 0;

--- a/src/util/DatasetReader.h
+++ b/src/util/DatasetReader.h
@@ -39,8 +39,6 @@
 	#include "zip.h"
 #endif
 
-#include <boost/thread.hpp>
-
 using namespace dso;
 
 

--- a/src/util/IndexThreadReduce.h
+++ b/src/util/IndexThreadReduce.h
@@ -24,8 +24,11 @@
 
 
 #pragma once
+#include <condition_variable>
+#include <thread>
+#include <functional>
+#include <mutex>
 #include "util/settings.h"
-#include "boost/thread.hpp"
 #include <stdio.h>
 #include <iostream>
 
@@ -46,14 +49,19 @@ public:
 		nextIndex = 0;
 		maxIndex = 0;
 		stepSize = 1;
-		callPerIndex = boost::bind(&IndexThreadReduce::callPerIndexDefault, this, _1, _2, _3, _4);
+		callPerIndex = std::bind(&IndexThreadReduce::callPerIndexDefault,
+				this,
+				std::placeholders::_1,
+				std::placeholders::_2,
+				std::placeholders::_3,
+				std::placeholders::_4);
 
 		running = true;
 		for(int i=0;i<NUM_THREADS;i++)
 		{
 			isDone[i] = false;
 			gotOne[i] = true;
-			workerThreads[i] = boost::thread(&IndexThreadReduce::workerLoop, this, i);
+			workerThreads[i] = std::thread(&IndexThreadReduce::workerLoop, this, i);
 		}
 
 	}
@@ -73,7 +81,7 @@ public:
 
 	}
 
-	inline void reduce(boost::function<void(int,int,Running*,int)> callPerIndex, int first, int end, int stepSize = 0)
+	inline void reduce(std::function<void(int,int,Running*,int)> callPerIndex, int first, int end, int stepSize = 0)
 	{
 
 		memset(&stats, 0, sizeof(Running));
@@ -92,7 +100,7 @@ public:
 
 		//printf("reduce called\n");
 
-		boost::unique_lock<boost::mutex> lock(exMutex);
+		std::unique_lock<std::mutex> lock(exMutex);
 
 		// save
 		this->callPerIndex = callPerIndex;
@@ -131,7 +139,12 @@ public:
 
 		nextIndex = 0;
 		maxIndex = 0;
-		this->callPerIndex = boost::bind(&IndexThreadReduce::callPerIndexDefault, this, _1, _2, _3, _4);
+		this->callPerIndex = std::bind(&IndexThreadReduce::callPerIndexDefault,
+				this,
+				std::placeholders::_1,
+				std::placeholders::_2,
+				std::placeholders::_3,
+				std::placeholders::_4);
 
 		//printf("reduce done (all threads finished)\n");
 	}
@@ -139,13 +152,13 @@ public:
 	Running stats;
 
 private:
-	boost::thread workerThreads[NUM_THREADS];
+	std::thread workerThreads[NUM_THREADS];
 	bool isDone[NUM_THREADS];
 	bool gotOne[NUM_THREADS];
 
-	boost::mutex exMutex;
-	boost::condition_variable todo_signal;
-	boost::condition_variable done_signal;
+	std::mutex exMutex;
+	std::condition_variable todo_signal;
+	std::condition_variable done_signal;
 
 	int nextIndex;
 	int maxIndex;
@@ -153,7 +166,7 @@ private:
 
 	bool running;
 
-	boost::function<void(int,int,Running*,int)> callPerIndex;
+	std::function<void(int,int,Running*,int)> callPerIndex;
 
 	void callPerIndexDefault(int i, int j,Running* k, int tid)
 	{
@@ -163,7 +176,7 @@ private:
 
 	void workerLoop(int idx)
 	{
-		boost::unique_lock<boost::mutex> lock(exMutex);
+		std::unique_lock<std::mutex> lock(exMutex);
 
 		while(running)
 		{

--- a/src/util/settings.cpp
+++ b/src/util/settings.cpp
@@ -24,8 +24,6 @@
 
 
 #include "util/settings.h"
-#include <boost/bind.hpp>
-
 
 namespace dso
 {


### PR DESCRIPTION
C++11 has all the features from boost used in the project.
Removing boost dependency simplifies porting solution to embedded devices.