### PR TITLE
Fix mac build, OpenCV4 compatibility, fix use-after-free causing memory corruption

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,17 +115,17 @@ add_library(dso ${dso_SOURCE_FILES} ${dso_opencv_SOURCE_FILES} ${dso_pangolin_SO
 #set_property( TARGET dso APPEND_STRING PROPERTY COMPILE_FLAGS -Wall )
 
 
-if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin") # OSX
-    set(BOOST_THREAD_LIBRARY boost_thread-mt)
-else()
-    set(BOOST_THREAD_LIBRARY boost_thread)
-endif()
+#if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin") # OSX
+#    set(BOOST_THREAD_LIBRARY boost_thread-mt)
+#else()
+#    set(BOOST_THREAD_LIBRARY boost_thread)
+#endif()
 
 # build main executable (only if we have both OpenCV and Pangolin)
 if (OpenCV_FOUND AND Pangolin_FOUND)
 	message("--- compiling dso_dataset.")
 	add_executable(dso_dataset ${PROJECT_SOURCE_DIR}/src/main_dso_pangolin.cpp )
-    target_link_libraries(dso_dataset dso boost_system cxsparse ${BOOST_THREAD_LIBRARY} ${LIBZIP_LIBRARY} ${Pangolin_LIBRARIES} ${OpenCV_LIBS})
+    target_link_libraries(dso_dataset dso ${Boost_LIBRARIES} ${CSPARSE_LIBRARY} ${BOOST_THREAD_LIBRARY} ${LIBZIP_LIBRARY} ${Pangolin_LIBRARIES} ${OpenCV_LIBS})
 else()
 	message("--- not building dso_dataset, since either don't have openCV or Pangolin.")
 endif()

--- a/src/FullSystem/FullSystemMarginalize.cpp
+++ b/src/FullSystem/FullSystemMarginalize.cpp
@@ -172,9 +172,9 @@ void FullSystem::marginalizeFrame(FrameHessian* frame)
 				if(r->target == frame)
 				{
 					if(ph->lastResiduals[0].first == r)
-						ph->lastResiduals[0].first=0;
+						ph->lastResiduals[0].first=nullptr;
 					else if(ph->lastResiduals[1].first == r)
-						ph->lastResiduals[1].first=0;
+						ph->lastResiduals[1].first=nullptr;
 
 
 					if(r->host->frameID < r->target->frameID)
@@ -190,7 +190,9 @@ void FullSystem::marginalizeFrame(FrameHessian* frame)
 		}
 	}
 
-
+    // efFrame is only unused once we finish droppping residuals
+    delete frame->efFrame;
+    frame->efFrame = nullptr;
 
     {
         std::vector<FrameHessian*> v;
@@ -206,8 +208,6 @@ void FullSystem::marginalizeFrame(FrameHessian* frame)
 	deleteOutOrder<FrameHessian>(frameHessians, frame);
 	for(unsigned int i=0;i<frameHessians.size();i++)
 		frameHessians[i]->idx = i;
-
-
 
 
 	setPrecalcValues();

--- a/src/IOWrapper/OpenCV/ImageRW_OpenCV.cpp
+++ b/src/IOWrapper/OpenCV/ImageRW_OpenCV.cpp
@@ -34,7 +34,7 @@ namespace IOWrap
 {
 MinimalImageB* readImageBW_8U(std::string filename)
 {
-	cv::Mat m = cv::imread(filename, CV_LOAD_IMAGE_GRAYSCALE);
+	cv::Mat m = cv::imread(filename, cv::ImreadModes::IMREAD_GRAYSCALE);
 	if(m.rows*m.cols==0)
 	{
 		printf("cv::imread could not read image %s! this may segfault. \n", filename.c_str());
@@ -52,7 +52,7 @@ MinimalImageB* readImageBW_8U(std::string filename)
 
 MinimalImageB3* readImageRGB_8U(std::string filename)
 {
-	cv::Mat m = cv::imread(filename, CV_LOAD_IMAGE_COLOR);
+	cv::Mat m = cv::imread(filename, cv::ImreadModes::IMREAD_COLOR);
 	if(m.rows*m.cols==0)
 	{
 		printf("cv::imread could not read image %s! this may segfault. \n", filename.c_str());
@@ -70,7 +70,7 @@ MinimalImageB3* readImageRGB_8U(std::string filename)
 
 MinimalImage<unsigned short>* readImageBW_16U(std::string filename)
 {
-	cv::Mat m = cv::imread(filename, CV_LOAD_IMAGE_UNCHANGED);
+	cv::Mat m = cv::imread(filename, cv::ImreadModes::IMREAD_UNCHANGED);
 	if(m.rows*m.cols==0)
 	{
 		printf("cv::imread could not read image %s! this may segfault. \n", filename.c_str());
@@ -88,7 +88,7 @@ MinimalImage<unsigned short>* readImageBW_16U(std::string filename)
 
 MinimalImageB* readStreamBW_8U(char* data, int numBytes)
 {
-	cv::Mat m = cv::imdecode(cv::Mat(numBytes,1,CV_8U, data), CV_LOAD_IMAGE_GRAYSCALE);
+	cv::Mat m = cv::imdecode(cv::Mat(numBytes,1,CV_8U, data), cv::ImreadModes::IMREAD_GRAYSCALE);
 	if(m.rows*m.cols==0)
 	{
 		printf("cv::imdecode could not read stream (%d bytes)! this may segfault. \n", numBytes);

--- a/src/OptimizationBackend/EnergyFunctional.cpp
+++ b/src/OptimizationBackend/EnergyFunctional.cpp
@@ -260,7 +260,7 @@ void EnergyFunctional::accumulateSCF_MT(MatXX &H, VecX &b, bool MT)
 	}
 }
 
-void EnergyFunctional::resubstituteF_MT(VecX x, CalibHessian* HCalib, bool MT)
+void EnergyFunctional::resubstituteF_MT(const VecX &x, CalibHessian* HCalib, bool MT)
 {
 	assert(x.size() == CPARS+nFrames*8);
 
@@ -419,7 +419,6 @@ EFResidual* EnergyFunctional::insertResidual(PointFrameResidual* r)
 	EFResidual* efr = new EFResidual(r, r->point->efPoint, r->host->efFrame, r->target->efFrame);
 	efr->idxInAll = r->point->efPoint->residualsAll.size();
 	r->point->efPoint->residualsAll.push_back(efr);
-
     connectivityMap[(((uint64_t)efr->host->frameID) << 32) + ((uint64_t)efr->target->frameID)][0]++;
 
 	nResiduals++;
@@ -488,7 +487,6 @@ void EnergyFunctional::dropResidual(EFResidual* r)
 		r->host->data->shell->statistics_goodResOnThis++;
 	else
 		r->host->data->shell->statistics_outlierResOnThis++;
-
 
     connectivityMap[(((uint64_t)r->host->frameID) << 32) + ((uint64_t)r->target->frameID)][0]--;
 	nResiduals--;
@@ -583,7 +581,7 @@ void EnergyFunctional::marginalizeFrame(EFFrame* fh)
 	}
 	frames.pop_back();
 	nFrames--;
-	fh->data->efFrame=0;
+	fh->data->efFrame=nullptr;
 
 	assert((int)frames.size()*8+CPARS == (int)HM.rows());
 	assert((int)frames.size()*8+CPARS == (int)HM.cols());
@@ -606,7 +604,6 @@ void EnergyFunctional::marginalizeFrame(EFFrame* fh)
 	EFDeltaValid=false;
 
 	makeIDX();
-	delete fh;
 }
 
 
@@ -629,8 +626,9 @@ void EnergyFunctional::marginalizePointsF()
 			{
 				p->priorF *= setting_idepthFixPriorMargFac;
 				for(EFResidual* r : p->residualsAll)
-					if(r->isActive())
+                    if(r->isActive()) {
                         connectivityMap[(((uint64_t)r->host->frameID) << 32) + ((uint64_t)r->target->frameID)][1]++;
+                    }
 				allPointsToMarg.push_back(p);
 			}
 		}

--- a/src/OptimizationBackend/EnergyFunctional.h
+++ b/src/OptimizationBackend/EnergyFunctional.h
@@ -124,7 +124,7 @@ private:
 
 	VecX getStitchedDeltaF() const;
 
-	void resubstituteF_MT(VecX x, CalibHessian* HCalib, bool MT);
+	void resubstituteF_MT(const VecX &x, CalibHessian* HCalib, bool MT);
     void resubstituteFPt(const VecCf &xc, Mat18f* xAd, int min, int max, Vec10* stats, int tid);
 
 	void accumulateAF_MT(MatXX &H, VecX &b, bool MT);


### PR DESCRIPTION
I tested this out on Ubuntu 18.04 as well
OSX consistently crashes in the pangolin viewer because the connectivity graph is corrupted on frame publish. This, in turn, is because when marginalizing a frame, the EFFrame is freed and then used for updating the connectivity graph. This caused the connectivity graph to be accessed with invalid keys (target->frameID overwritten). However, std::map creates elements on access so invalid edges would be created instead of decrementing counts of existing edges.