### PR TITLE
update ImageRW_Opencv.cpp for opencv4

### DIFF
--- a/src/IOWrapper/OpenCV/ImageRW_OpenCV.cpp
+++ b/src/IOWrapper/OpenCV/ImageRW_OpenCV.cpp
@@ -34,7 +34,7 @@ namespace IOWrap
 {
 MinimalImageB* readImageBW_8U(std::string filename)
 {
-	cv::Mat m = cv::imread(filename, CV_LOAD_IMAGE_GRAYSCALE);
+	cv::Mat m = cv::imread(filename, cv::IMREAD_GRAYSCALE);
 	if(m.rows*m.cols==0)
 	{
 		printf("cv::imread could not read image %s! this may segfault. \n", filename.c_str());
@@ -52,7 +52,7 @@ MinimalImageB* readImageBW_8U(std::string filename)
 
 MinimalImageB3* readImageRGB_8U(std::string filename)
 {
-	cv::Mat m = cv::imread(filename, CV_LOAD_IMAGE_COLOR);
+	cv::Mat m = cv::imread(filename, cv::IMREAD_COLOR);
 	if(m.rows*m.cols==0)
 	{
 		printf("cv::imread could not read image %s! this may segfault. \n", filename.c_str());
@@ -70,7 +70,7 @@ MinimalImageB3* readImageRGB_8U(std::string filename)
 
 MinimalImage<unsigned short>* readImageBW_16U(std::string filename)
 {
-	cv::Mat m = cv::imread(filename, CV_LOAD_IMAGE_UNCHANGED);
+	cv::Mat m = cv::imread(filename, cv::IMREAD_UNCHANGED);
 	if(m.rows*m.cols==0)
 	{
 		printf("cv::imread could not read image %s! this may segfault. \n", filename.c_str());
@@ -88,7 +88,7 @@ MinimalImage<unsigned short>* readImageBW_16U(std::string filename)
 
 MinimalImageB* readStreamBW_8U(char* data, int numBytes)
 {
-	cv::Mat m = cv::imdecode(cv::Mat(numBytes,1,CV_8U, data), CV_LOAD_IMAGE_GRAYSCALE);
+	cv::Mat m = cv::imdecode(cv::Mat(numBytes,1,CV_8U, data), cv::IMREAD_GRAYSCALE);
 	if(m.rows*m.cols==0)
 	{
 		printf("cv::imdecode could not read stream (%d bytes)! this may segfault. \n", numBytes);


### PR DESCRIPTION
I changed from "CV_LOAD_IMAGE_*" to "cv::IMREAD_*"    
At opncv4, "CV_LOAD_IMAGE_*" was not supported.  
That change made me succeed to build at my environment.   